### PR TITLE
Fixed the recursive validation and added types validations with tests

### DIFF
--- a/library/Director/DataType/DataTypeDictionary.php
+++ b/library/Director/DataType/DataTypeDictionary.php
@@ -58,6 +58,8 @@ class DataTypeDictionary extends DataTypeHook
                 return [];
             case 'Icinga\Module\Director\DataType\DataTypeString':
                 return "";
+            case 'Icinga\Module\Director\DataType\DataTypeNumber':
+                return 0;
             case 'Icinga\Module\Director\DataType\DataTypeDictionary':
                 if ($field->setting_name === 'reference_id' && $field->setting_value) {
                     return $this->getDefaultValue($field->setting_value, $db);

--- a/library/Director/Web/Form/Element/Dictionary.php
+++ b/library/Director/Web/Form/Element/Dictionary.php
@@ -15,17 +15,28 @@ class Dictionary extends FormElement
         return $this->validateNode($this->structure, $value);
     }
 
-    protected function validateNode($structure, $value)
+    protected function validateNode($structure, $value, $keyPrefix = '')
     {
         if ($value === null) {
             return true;
         }
         foreach ($structure as $key => $node) {
-            if (!key_exists($key, $value)) {
-                $this->addError(sprintf("Key '%s' is missing", $key));
+            $fullKey = $keyPrefix . $key;
+
+            if ( ! key_exists($key, $value)) {
+                $this->addError(sprintf("Key '%s' is missing", $fullKey));
                 return false;
-            } elseif (is_array($value[$key]) && !$this->validateNode($node, $value[$key])) {
-                $this->addError(sprintf("Value for key %s: '%value%' is invalid", $key));
+            }
+
+            if (is_array($value[$key]) && ! $this->validateNode($node, $value[$key], $key . '.')) {
+                return false;
+            }
+
+            $expectedType = gettype($structure[$key]);
+            $currentType = gettype($value[$key]);
+            if ($expectedType !== $currentType) {
+                $this->addError(sprintf("Type mismatch, '%s' is expected to be a '%s', '%s' given",
+                    $fullKey, $expectedType, $currentType));
                 return false;
             }
         }

--- a/library/Director/Web/Form/Element/Dictionary.php
+++ b/library/Director/Web/Form/Element/Dictionary.php
@@ -6,6 +6,7 @@ class Dictionary extends FormElement
 {
     public $helper = 'formDictionary';
     private $structure = null;
+    private $fieldSettingsMap = [];
 
     public function isValid($value, $context = null)
     {
@@ -28,13 +29,18 @@ class Dictionary extends FormElement
                 return false;
             }
 
-            if (is_array($value[$key]) && ! $this->validateNode($node, $value[$key], $key . '.')) {
+            if (is_array($value[$key]) && ! $this->validateNode($node, $value[$key], $fullKey . '.')) {
+                return false;
+            }
+
+            if ($this->fieldSettingsMap[$fullKey]['is_required'] && $value[$key] === null) {
+                $this->addError(sprintf("Key '%s' is required and cannot be NULL", $fullKey));
                 return false;
             }
 
             $expectedType = gettype($structure[$key]);
             $currentType = gettype($value[$key]);
-            if ($expectedType !== $currentType) {
+            if ($expectedType !== $currentType && $value[$key] !== null) {
                 $this->addError(sprintf("Type mismatch, '%s' is expected to be a '%s', '%s' given",
                     $fullKey, $expectedType, $currentType));
                 return false;
@@ -47,6 +53,16 @@ class Dictionary extends FormElement
     {
         $this->structure = $value;
         $this->setValue($value);
+    }
+
+    public function setFieldSettingsMap($fieldSettingsMap)
+    {
+        $this->fieldSettingsMap = $fieldSettingsMap;
+    }
+
+    public function getFieldSettingsMap()
+    {
+        return $this->fieldSettingsMap;
     }
 
     public function setValue($value)

--- a/test/php/library/Director/DataType/DataTypeDictionaryTest.php
+++ b/test/php/library/Director/DataType/DataTypeDictionaryTest.php
@@ -56,6 +56,18 @@ class DataTypeDictionaryTest extends BaseTestCase
         $this->assertEquals('{"foobar-sub-dict":{"foobar-sub-string":""}}', json_encode($element->getValue()));
     }
 
+    public function testGetDictionaryFieldSettingsMap() {
+        $this->havingDictionaryWithRecursion();
+
+        $element = $this->getTestedElement();
+
+        $fieldSettingsMap = $element->getFieldSettingsMap();
+
+        $this->assertEquals(2, count(array_keys($fieldSettingsMap)));
+        $this->assertTrue($fieldSettingsMap['foobar-sub-dict']['is_required']);
+        $this->assertFalse($fieldSettingsMap['foobar-sub-dict.foobar-sub-string']['is_required']);
+    }
+
     private function getTestedElement() {
         $quickForm = new TestQuickForm($this);
         $quickForm->setDb($this->getDb());
@@ -142,7 +154,7 @@ class DataTypeDictionaryTest extends BaseTestCase
             'varname' => 'foobar-sub-dict',
             'caption' => 'FOOBAR SUD DICT',
             'datatype' => 'Icinga\\Module\\Director\\DataType\\DataTypeDictionary',
-            'is_required' => 'n',
+            'is_required' => 'y',
             'allow_multiple' => 'n',
             'reference_id' => $subDictId
         ]);

--- a/test/php/library/Director/DataType/DataTypeDictionaryTest.php
+++ b/test/php/library/Director/DataType/DataTypeDictionaryTest.php
@@ -18,18 +18,22 @@ class DataTypeDictionaryTest extends BaseTestCase
     public function setUp() {
         parent::setUp();
         $this->dataType = new DataTypeDictionary();
+
+        $this->skipForMissingDb();
     }
 
     public function tearDown() {
-        foreach ($this->dictionaryFields as $dictionaryField) {
-            DirectorDictionaryField::load($dictionaryField->getId(), $this->getDb())->delete();
-        }
-        $this->dictionaryFields = [];
+        if ($this->hasDb()) {
+            foreach ($this->dictionaryFields as $dictionaryField) {
+                DirectorDictionaryField::load($dictionaryField->getId(), $this->getDb())->delete();
+            }
+            $this->dictionaryFields = [];
 
-        foreach ($this->dictionaries as $dictionary) {
-            DirectorDictionary::load($dictionary->getId(), $this->getDb())->delete();
+            foreach ($this->dictionaries as $dictionary) {
+                DirectorDictionary::load($dictionary->getId(), $this->getDb())->delete();
+            }
+            $this->dictionaries = [];
         }
-        $this->dictionaries = [];
     }
 
     public function testGetDictionaryFormElementWithoutFields() {

--- a/test/php/library/Director/DataType/DataTypeDictionaryTest.php
+++ b/test/php/library/Director/DataType/DataTypeDictionaryTest.php
@@ -45,7 +45,7 @@ class DataTypeDictionaryTest extends BaseTestCase
 
         $element = $this->getTestedElement();
 
-        $this->assertEquals('{"foobar-arr":[],"foobar-dict":null,"foobar-str":""}', json_encode($element->getValue()));
+        $this->assertEquals('{"foobar-arr":[],"foobar-dict":null,"foobar-number":0,"foobar-str":""}', json_encode($element->getValue()));
     }
 
     public function testGetDictionaryFormElementWithRecursion() {
@@ -80,6 +80,17 @@ class DataTypeDictionaryTest extends BaseTestCase
             'varname' => 'foobar-str',
             'caption' => 'FOOBAR STRING',
             'datatype' => 'Icinga\\Module\\Director\\DataType\\DataTypeString',
+            'is_required' => 'n',
+            'allow_multiple' => 'n'
+        ]);
+        $tempDictionaryField->store($this->getDb());
+        array_push($this->dictionaryFields, $tempDictionaryField);
+
+        $tempDictionaryField = DirectorDictionaryField::create([
+            'dictionary_id' => $tempDictionary->getId(),
+            'varname' => 'foobar-number',
+            'caption' => 'FOOBAR NUMBER',
+            'datatype' => 'Icinga\\Module\\Director\\DataType\\DataTypeNumber',
             'is_required' => 'n',
             'allow_multiple' => 'n'
         ]);

--- a/test/php/library/Director/Web/Form/Element/DictionaryTest.php
+++ b/test/php/library/Director/Web/Form/Element/DictionaryTest.php
@@ -19,6 +19,10 @@ class DictionaryTest extends BaseTestCase
             'key_one' => 0,
             'key_two' => ''
         ]);
+        $this->dictionaryInstance->setFieldSettingsMap([
+            'key_one' => ['is_required' => true],
+            'key_two' => ['is_required' => true],
+        ]);
 
         $this->dictionaryInstance->isValid([
             'key_one' => 42,
@@ -33,6 +37,11 @@ class DictionaryTest extends BaseTestCase
             'key_one' => 0,
             'key_two' => '',
             'key_three' => ''
+        ]);
+        $this->dictionaryInstance->setFieldSettingsMap([
+            'key_one' => ['is_required' => true],
+            'key_two' => ['is_required' => true],
+            'key_three' => ['is_required' => true],
         ]);
 
         $this->dictionaryInstance->isValid([
@@ -53,6 +62,11 @@ class DictionaryTest extends BaseTestCase
                 'sub_key_one' => ''
             ]
         ]);
+        $this->dictionaryInstance->setFieldSettingsMap([
+            'key_one' => ['is_required' => true],
+            'key_two' => ['is_required' => true],
+            'key_two.sub_key_one' => ['is_required' => true],
+        ]);
 
         $this->dictionaryInstance->isValid([
             'key_one' => 0,
@@ -68,6 +82,9 @@ class DictionaryTest extends BaseTestCase
     public function testDictionaryWithKeyTypeMismatch() {
         $this->dictionaryInstance->setDefaultValue([
             'key_one' => 0
+        ]);
+        $this->dictionaryInstance->setFieldSettingsMap([
+            'key_one' => ['is_required' => true]
         ]);
 
         $this->dictionaryInstance->isValid([
@@ -85,8 +102,55 @@ class DictionaryTest extends BaseTestCase
             'key_one' => 0,
             'key_two' => ''
         ]);
+        $this->dictionaryInstance->setFieldSettingsMap([
+            'key_one' => ['is_required' => true],
+            'key_two' => ['is_required' => true],
+        ]);
 
         $this->dictionaryInstance->isValid('{"key_one" : 42,"key_two" : "foobar"}');
+
+        $this->assertFalse($this->dictionaryInstance->hasErrors());
+    }
+
+    public function testRequiredFieldCantBeNull() {
+        $this->dictionaryInstance->setDefaultValue([
+            'key_one' => [
+                'sub_key_one' => ''
+            ]
+        ]);
+        $this->dictionaryInstance->setFieldSettingsMap([
+            'key_one' => ['is_required' => true],
+            'key_one.sub_key_one' => ['is_required' => true],
+        ]);
+
+        $this->dictionaryInstance->isValid([
+            'key_one' => [
+                'sub_key_one' => null
+            ]
+        ]);
+
+        $this->assertTrue($this->dictionaryInstance->hasErrors());
+        $errors = $this->dictionaryInstance->getMessages();
+        $this->assertEquals(1, count($errors));
+        $this->assertEquals('Key \'key_one.sub_key_one\' is required and cannot be NULL', $errors[0]);
+    }
+
+    public function testNonRequiredFieldCanBeNull() {
+        $this->dictionaryInstance->setDefaultValue([
+            'key_one' => [
+                'sub_key_one' => ''
+            ]
+        ]);
+        $this->dictionaryInstance->setFieldSettingsMap([
+            'key_one' => ['is_required' => true],
+            'key_one.sub_key_one' => ['is_required' => false],
+        ]);
+
+        $this->dictionaryInstance->isValid([
+            'key_one' => [
+                'sub_key_one' => null
+            ]
+        ]);
 
         $this->assertFalse($this->dictionaryInstance->hasErrors());
     }

--- a/test/php/library/Director/Web/Form/Element/DictionaryTest.php
+++ b/test/php/library/Director/Web/Form/Element/DictionaryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Icinga\Module\Director\Web\Form\Element;
+
+use Icinga\Module\Director\Test\BaseTestCase;
+use Icinga\Module\Director\Web\Form\Element\Dictionary;
+
+class DictionaryTest extends BaseTestCase
+{
+    protected $dictionaryInstance;
+
+    public function setUp() {
+        parent::setUp();
+        $this->dictionaryInstance = new Dictionary('fake_name');
+    }
+
+    public function testValidDictionary() {
+        $this->dictionaryInstance->setDefaultValue([
+            'key_one' => 0,
+            'key_two' => ''
+        ]);
+
+        $this->dictionaryInstance->isValid([
+            'key_one' => 42,
+            'key_two' => 'foobar'
+        ]);
+
+        $this->assertFalse($this->dictionaryInstance->hasErrors());
+    }
+
+    public function testDictionaryWithMissingKey() {
+        $this->dictionaryInstance->setDefaultValue([
+            'key_one' => 0,
+            'key_two' => '',
+            'key_three' => ''
+        ]);
+
+        $this->dictionaryInstance->isValid([
+            'key_one' => 42,
+            'key_two' => 'foobar'
+        ]);
+
+        $this->assertTrue($this->dictionaryInstance->hasErrors());
+        $errors = $this->dictionaryInstance->getMessages();
+        $this->assertEquals(1, count($errors));
+        $this->assertEquals('Key \'key_three\' is missing', $errors[0]);
+    }
+
+    public function testDictionaryWithMissingSubkey() {
+        $this->dictionaryInstance->setDefaultValue([
+            'key_one' => 0,
+            'key_two' => [
+                'sub_key_one' => ''
+            ]
+        ]);
+
+        $this->dictionaryInstance->isValid([
+            'key_one' => 0,
+            'key_two' => []
+        ]);
+
+        $this->assertTrue($this->dictionaryInstance->hasErrors());
+        $errors = $this->dictionaryInstance->getMessages();
+        $this->assertEquals(1, count($errors));
+        $this->assertEquals('Key \'key_two.sub_key_one\' is missing', $errors[0]);
+    }
+
+    public function testDictionaryWithKeyTypeMismatch() {
+        $this->dictionaryInstance->setDefaultValue([
+            'key_one' => 0
+        ]);
+
+        $this->dictionaryInstance->isValid([
+            'key_one' => 'oh no a string'
+        ]);
+
+        $this->assertTrue($this->dictionaryInstance->hasErrors());
+        $errors = $this->dictionaryInstance->getMessages();
+        $this->assertEquals(1, count($errors));
+        $this->assertEquals('Type mismatch, \'key_one\' is expected to be a \'integer\', \'string\' given', $errors[0]);
+    }
+
+    public function testDictionaryValidationWithRawJson() {
+        $this->dictionaryInstance->setDefaultValue([
+            'key_one' => 0,
+            'key_two' => ''
+        ]);
+
+        $this->dictionaryInstance->isValid('{"key_one" : 42,"key_two" : "foobar"}');
+
+        $this->assertFalse($this->dictionaryInstance->hasErrors());
+    }
+}

--- a/test/php/library/Director/Web/Form/Element/DictionaryTest.php
+++ b/test/php/library/Director/Web/Form/Element/DictionaryTest.php
@@ -39,9 +39,9 @@ class DictionaryTest extends BaseTestCase
             'key_three' => ''
         ]);
         $this->dictionaryInstance->setFieldSettingsMap([
-            'key_one' => ['is_required' => true],
-            'key_two' => ['is_required' => true],
-            'key_three' => ['is_required' => true],
+            'key_one' => ['is_required' => false],
+            'key_two' => ['is_required' => false],
+            'key_three' => ['is_required' => false],
         ]);
 
         $this->dictionaryInstance->isValid([
@@ -65,7 +65,7 @@ class DictionaryTest extends BaseTestCase
         $this->dictionaryInstance->setFieldSettingsMap([
             'key_one' => ['is_required' => true],
             'key_two' => ['is_required' => true],
-            'key_two.sub_key_one' => ['is_required' => true],
+            'key_two.sub_key_one' => ['is_required' => false],
         ]);
 
         $this->dictionaryInstance->isValid([
@@ -84,7 +84,7 @@ class DictionaryTest extends BaseTestCase
             'key_one' => 0
         ]);
         $this->dictionaryInstance->setFieldSettingsMap([
-            'key_one' => ['is_required' => true]
+            'key_one' => ['is_required' => false]
         ]);
 
         $this->dictionaryInstance->isValid([
@@ -103,8 +103,8 @@ class DictionaryTest extends BaseTestCase
             'key_two' => ''
         ]);
         $this->dictionaryInstance->setFieldSettingsMap([
-            'key_one' => ['is_required' => true],
-            'key_two' => ['is_required' => true],
+            'key_one' => ['is_required' => false],
+            'key_two' => ['is_required' => false],
         ]);
 
         $this->dictionaryInstance->isValid('{"key_one" : 42,"key_two" : "foobar"}');


### PR DESCRIPTION
For "regular" fields, the validations seems to be done in the form fields, I didn't find any way of re-using this logic there. The validation recursively check if all keys are present and check for proper field types. 
